### PR TITLE
doc: Add note about staging flake.nix

### DIFF
--- a/doc/setup.md
+++ b/doc/setup.md
@@ -75,8 +75,10 @@ Note: Your system Nix might print warnings about not knowing some of the setting
 From a Lean shell, run
 ```bash
 $ nix flake new mypkg -t github:leanprover/lean4
+$ cd mypkg && git init && git add flake.nix
 ```
 to create a new Lean package in directory `mypkg` using the latest commit of Lean 4.
+Note that Nix Flakes will not recognize your `flake.nix` file unless it is visible to Git.
 Such packages follow the same directory layout as described in the basic setup above, except for a `leanpkg.toml` replaced by a `flake.nix` file set up so you can run Nix commands on it, for example:
 ```bash
 $ nix build  # build package and all dependencies


### PR DESCRIPTION
I just tried to set up Lean under NixOS according to [the docs](https://leanprover.github.io/lean4/doc/setup.html) and ran into the following issue:

If you don't make flake.nix visible to Git, nix build etc. won't work (see [this blog post](https://www.tweag.io/blog/2020-05-25-flakes/)). This PR adds a command that adds the file to the Index and a note explaining why.

To reproduce:

```
$ nix flake new test
$ cd test
$ nix build
error: source tree referenced by 'git+file:///[...]' does not contain a '[...]/flake.nix' file
```